### PR TITLE
Added compare_raw_slices function to ORECipher

### DIFF
--- a/benches/oreaes128.rs
+++ b/benches/oreaes128.rs
@@ -19,7 +19,12 @@ fn do_encrypt_left_64(input: u64, ore: &mut OREAES128) {
 
 #[inline]
 fn do_compare<const N: usize>(a: &CipherText<OREAES128, N>, b: &CipherText<OREAES128, N>) {
-    a.partial_cmp(b);
+    let _ret = a.partial_cmp(b);
+}
+
+#[inline]
+fn do_compare_slice(a: &[u8], b: &[u8]) {
+    let _ret = OREAES128::compare_raw_slices(a, b);
 }
 
 #[inline]
@@ -51,7 +56,8 @@ fn criterion_benchmark(c: &mut Criterion) {
     let x_u64 = 100_u64.encrypt(&mut ore).unwrap();
     let y_u64 = 100983939290192_u64.encrypt(&mut ore).unwrap();
 
-    let bytes = x_u64.to_bytes();
+    let x_bytes = x_u64.to_bytes();
+    let y_bytes = y_u64.to_bytes();
 
     let x_u32 = 100_u32.encrypt(&mut ore).unwrap();
     let y_u32 = 10098393_u32.encrypt(&mut ore).unwrap();
@@ -59,8 +65,9 @@ fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("encrypt-8", |b| b.iter(|| do_encrypt_64(25u64, black_box(&mut ore))));
     c.bench_function("encrypt-left-8", |b| b.iter(|| do_encrypt_left_64(25u64, black_box(&mut ore))));
     c.bench_function("compare-8", |b| b.iter(|| do_compare(black_box(&x_u64), black_box(&y_u64))));
+    c.bench_function("compare-8-slice", |b| b.iter(|| do_compare_slice(black_box(&x_bytes), black_box(&y_bytes))));
     c.bench_function("serialize-8", |b| b.iter(|| do_serialize(black_box(&x_u64))));
-    c.bench_function("deserialize-8", |b| b.iter(|| do_deserialize(black_box(&bytes))));
+    c.bench_function("deserialize-8", |b| b.iter(|| do_deserialize(black_box(&x_bytes))));
 
     c.bench_function("encrypt-4", |b| b.iter(|| do_encrypt_32(25u32, black_box(&mut ore))));
     c.bench_function("encrypt-left-4", |b| b.iter(|| do_encrypt_left_32(25u32, black_box(&mut ore))));

--- a/src/ciphertext.rs
+++ b/src/ciphertext.rs
@@ -82,7 +82,7 @@ where <S as ORECipher>::RightBlockType: CipherTextBlock
     }
 
     pub fn size() -> usize {
-        N * S::RightBlockType::BLOCK_SIZE + NONCE_SIZE
+        (N * S::RightBlockType::BLOCK_SIZE) + NONCE_SIZE
     }
 
     pub fn to_bytes(&self) -> Vec<u8> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,8 +144,9 @@ pub mod scheme;
 
 pub use crate::encrypt::OREEncrypt;
 pub use crate::ciphertext::*;
-
+use std::cmp::Ordering;
 use crate::primitives::SEED64;
+
 pub type PlainText<const N: usize> = [u8; N];
 
 #[derive(Debug, Clone)]
@@ -167,6 +168,8 @@ pub trait ORECipher: Sized {
     ) -> Result<CipherText<Self, N>, OREError>
         where <Self as ORECipher>::RightBlockType: CipherTextBlock,
               <Self as ORECipher>::LeftBlockType: ciphertext::CipherTextBlock;
+
+    fn compare_raw_slices(a: &[u8], b: &[u8]) -> Option<Ordering>;
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,6 @@ use ore_rs::{
     scheme::bit2::OREAES128,
     OREEncrypt,
     ORECipher,
-    CipherText
 };
 use hex_literal::hex;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,12 +14,13 @@ fn main() {
 
     let mut ore: OREAES128 = ORECipher::init(k1, k2, &seed).unwrap();
 
-    let cta = 1u64.encrypt(&mut ore).unwrap();
-    let ctb = 50u64.encrypt(&mut ore).unwrap();
-    println!("1 > 50 = {}", cta > ctb);
+    let cta = 0u64.encrypt(&mut ore).unwrap();
+    let ctb = 0u64.encrypt(&mut ore).unwrap();
+    //println!("1 > 50 = {}", cta > ctb);
 
-    println!("A left = {:?}", cta.left);
+    println!("RET = {:?}", OREAES128::compare_raw_slices(&cta.to_bytes(), &ctb.to_bytes()));
 
-    let bytes = cta.to_bytes();
-    let _ct = CipherText::<OREAES128, 8>::from_bytes(&bytes).unwrap();
+
+    //let bytes = cta.to_bytes();
+    //let _ct = CipherText::<OREAES128, 8>::from_bytes(&bytes).unwrap();
 }

--- a/src/scheme/bit2.rs
+++ b/src/scheme/bit2.rs
@@ -447,10 +447,10 @@ mod tests {
     #[test]
     fn compare_raw_slices_mismatched_lengths() {
         let mut ore = init_ore();
-        let a = 10u64.encrypt(&mut ore).unwrap().to_bytes();
-        let b = 73u32.encrypt(&mut ore).unwrap().to_bytes();
+        let a_64 = 10u64.encrypt(&mut ore).unwrap().to_bytes();
+        let a_32 = 10u32.encrypt(&mut ore).unwrap().to_bytes();
 
-        assert_eq!(OREAES128::compare_raw_slices(&a, &b), Option::None);
+        assert_eq!(OREAES128::compare_raw_slices(&a_64, &a_32), Option::None);
     }
 
     #[test]


### PR DESCRIPTION
This adds a function to compare ORE ciphertexts directly via their raw slices (`&[u8]`).

I don't think this is going to be the best way forward and instead would like to explore the use of a single slice as an internal data structure for CipherTexts that should allow very simple (and fast) implementation of `Clone` and a `from_slice` function. That would allow the use of the structure data types and make things a bit more robust without sacrificing performance.

Note that this PR also changes the internals of the `RightBlock32` type to use an array of bytes rather than 2 `u128`s as a step towards the above.