### PR TITLE
use compatible version of 'fake'

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license-file = "COPYING"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dev-dependencies]
 criterion = "0.3.5"
-fake = "2.4.0"
+fake = "2.4.0, < 2.4.2"
 quickcheck = "1.0.3"
 
 [dependencies]


### PR DESCRIPTION
Versions of 'fake' beyond 2.4.1 require the 2021 edition of Rust, which isn't
in the version of Rust listed in .tool-versions.