### PR TITLE
Added encrypt trait implementation for PlainText<8>

### DIFF
--- a/src/encrypt.rs
+++ b/src/encrypt.rs
@@ -1,6 +1,7 @@
 use crate::ciphertext::*;
 use crate::{ORECipher, OREError};
 use crate::convert::ToOrderedInteger;
+use crate::PlainText;
 
 pub trait OREEncrypt<T: ORECipher> {
     type LeftOutput;
@@ -76,5 +77,22 @@ where
     fn encrypt(&self, cipher: &mut T) -> Result<Self::FullOutput, OREError> {
         let plaintext: u64 = self.map_to();
         return plaintext.encrypt(cipher);
+    }
+}
+
+impl<T: ORECipher, const N: usize> OREEncrypt<T> for PlainText<N>
+where
+    <T as ORECipher>::LeftBlockType: CipherTextBlock,
+    <T as ORECipher>::RightBlockType: CipherTextBlock,
+{
+    type LeftOutput = Left<T, N>;
+    type FullOutput = CipherText<T, N>;
+
+    fn encrypt_left(&self, cipher: &mut T) -> Result<Self::LeftOutput, OREError> {
+        return cipher.encrypt_left(&self);
+    }
+
+    fn encrypt(&self, cipher: &mut T) -> Result<Self::FullOutput, OREError> {
+        return cipher.encrypt(&self);
     }
 }

--- a/src/scheme/bit2.rs
+++ b/src/scheme/bit2.rs
@@ -405,6 +405,26 @@ mod tests {
 
             return a == b;
         }
+
+        fn compare_plaintext(x: u64, y: u64) -> bool {
+            let mut ore = init_ore();
+            let a = x.to_be_bytes().encrypt(&mut ore).unwrap();
+            let b = y.to_be_bytes().encrypt(&mut ore).unwrap();
+
+            return match x.cmp(&y) {
+                Ordering::Greater => a > b,
+                Ordering::Less    => a < b,
+                Ordering::Equal   => a == b
+            };
+        }
+
+        fn equality_plaintext(x: f64) -> bool {
+            let mut ore = init_ore();
+            let a = x.to_be_bytes().encrypt(&mut ore).unwrap();
+            let b = x.to_be_bytes().encrypt(&mut ore).unwrap();
+
+            return a == b;
+        }
     }
 
     #[test]


### PR DESCRIPTION
* Added a trait implementation for `Encrypt` for `PlainText` to make it a little easier to use (we can chain methods now)