### PR TITLE
Simplify ORECipher left/right constraints

### DIFF
--- a/src/ciphertext.rs
+++ b/src/ciphertext.rs
@@ -2,10 +2,7 @@ use crate::primitives::{AesBlock, NONCE_SIZE};
 pub use crate::ORECipher;
 
 #[derive(Debug, Copy, Clone)]
-pub struct Left<S: ORECipher, const N: usize>
-where
-    <S as ORECipher>::LeftBlockType: CipherTextBlock,
-{
+pub struct Left<S: ORECipher, const N: usize> {
     /* Array of Left blocks of size N */
     pub f: [S::LeftBlockType; N],
 
@@ -14,20 +11,13 @@ where
 }
 
 #[derive(Debug, Copy, Clone)]
-pub struct Right<S: ORECipher, const N: usize>
-where
-    <S as ORECipher>::RightBlockType: CipherTextBlock,
-{
+pub struct Right<S: ORECipher, const N: usize> {
     pub nonce: AesBlock,
     pub data: [S::RightBlockType; N],
 }
 
 #[derive(Debug, Copy, Clone)]
-pub struct CipherText<S: ORECipher, const N: usize>
-where
-    <S as ORECipher>::LeftBlockType: CipherTextBlock,
-    <S as ORECipher>::RightBlockType: CipherTextBlock,
-{
+pub struct CipherText<S: ORECipher, const N: usize> {
     pub left: Left<S, N>,
     pub right: Right<S, N>,
 }
@@ -37,16 +27,14 @@ pub trait CipherTextBlock: Default + Copy + std::fmt::Debug {
 
     // TODO: I wonder if we should be using &[u8] slices with lifetimes? (See pgx for inspo)
     fn to_bytes(self) -> Vec<u8>;
+
     fn from_bytes(data: &[u8]) -> Result<Self, ParseError>;
 }
 
 #[derive(Debug)]
 pub struct ParseError;
 
-impl<S: ORECipher, const N: usize> Left<S, N>
-where
-    <S as ORECipher>::LeftBlockType: CipherTextBlock,
-{
+impl<S: ORECipher, const N: usize> Left<S, N> {
     pub(crate) fn init() -> Self {
         Self {
             xt: [0; N],
@@ -81,10 +69,7 @@ where
     }
 }
 
-impl<S: ORECipher, const N: usize> Right<S, N>
-where
-    <S as ORECipher>::RightBlockType: CipherTextBlock,
-{
+impl<S: ORECipher, const N: usize> Right<S, N> {
     pub(crate) fn init() -> Self {
         Self {
             nonce: Default::default(),
@@ -118,11 +103,7 @@ where
     }
 }
 
-impl<S: ORECipher, const N: usize> CipherText<S, N>
-where
-    <S as ORECipher>::LeftBlockType: CipherTextBlock,
-    <S as ORECipher>::RightBlockType: CipherTextBlock,
-{
+impl<S: ORECipher, const N: usize> CipherText<S, N> {
     pub fn to_bytes(&self) -> Vec<u8> {
         [self.left.to_bytes(), self.right.to_bytes()].concat()
     }

--- a/src/encrypt.rs
+++ b/src/encrypt.rs
@@ -14,11 +14,7 @@ pub trait OREEncrypt<T: ORECipher> {
 // FIXME: I don't like that the cipher is mutable - its private members are mutable
 // TODO: Perhaps we could make the implementations default for the trait and control things
 // with the types. Only need to override for things like floats.
-impl<T: ORECipher> OREEncrypt<T> for u64
-where
-    <T as ORECipher>::LeftBlockType: CipherTextBlock,
-    <T as ORECipher>::RightBlockType: CipherTextBlock,
-{
+impl<T: ORECipher> OREEncrypt<T> for u64 {
     /* Note that Rust currently doesn't allow
      * generic associated types so this ia a bit verbose! */
     type LeftOutput = Left<T, 8>;
@@ -42,11 +38,7 @@ where
     }
 }
 
-impl<T: ORECipher> OREEncrypt<T> for u32
-where
-    <T as ORECipher>::LeftBlockType: CipherTextBlock,
-    <T as ORECipher>::RightBlockType: CipherTextBlock,
-{
+impl<T: ORECipher> OREEncrypt<T> for u32 {
     type LeftOutput = Left<T, 4>;
     type FullOutput = CipherText<T, 4>;
 
@@ -61,11 +53,7 @@ where
     }
 }
 
-impl<T: ORECipher> OREEncrypt<T> for f64
-where
-    <T as ORECipher>::LeftBlockType: CipherTextBlock,
-    <T as ORECipher>::RightBlockType: CipherTextBlock,
-{
+impl<T: ORECipher> OREEncrypt<T> for f64 {
     type LeftOutput = Left<T, 8>;
     type FullOutput = CipherText<T, 8>;
 
@@ -80,11 +68,7 @@ where
     }
 }
 
-impl<T: ORECipher, const N: usize> OREEncrypt<T> for PlainText<N>
-where
-    <T as ORECipher>::LeftBlockType: CipherTextBlock,
-    <T as ORECipher>::RightBlockType: CipherTextBlock,
-{
+impl<T: ORECipher, const N: usize> OREEncrypt<T> for PlainText<N> {
     type LeftOutput = Left<T, N>;
     type FullOutput = CipherText<T, N>;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,25 +154,20 @@ pub type PlainText<const N: usize> = [u8; N];
 pub struct OREError;
 
 pub trait ORECipher: Sized {
-    type LeftBlockType;
-    type RightBlockType;
+    type LeftBlockType: CipherTextBlock;
+    type RightBlockType: CipherTextBlock;
 
     fn init(k1: [u8; 16], k2: [u8; 16], seed: &SEED64) -> Result<Self, OREError>;
 
     fn encrypt_left<const N: usize>(
         &mut self,
         input: &PlainText<N>,
-    ) -> Result<Left<Self, N>, OREError>
-    where
-        <Self as ORECipher>::LeftBlockType: CipherTextBlock;
+    ) -> Result<Left<Self, N>, OREError>;
 
     fn encrypt<const N: usize>(
         &mut self,
         input: &PlainText<N>,
-    ) -> Result<CipherText<Self, N>, OREError>
-    where
-        <Self as ORECipher>::RightBlockType: CipherTextBlock,
-        <Self as ORECipher>::LeftBlockType: ciphertext::CipherTextBlock;
+    ) -> Result<CipherText<Self, N>, OREError>;
 
     fn compare_raw_slices(a: &[u8], b: &[u8]) -> Option<Ordering>;
 }


### PR DESCRIPTION
By hoisting the constraint for the `LeftBlockType` and `RightBlockType` associated types to the top level you can avoid a bunch of where clauses in the trait impls.

Not sure if there are any extra implications with this - but it seems to build/test fine.
