### PR TITLE
Bump ore-rs to 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0]
+
 ### Added
 
 * Copy and Clone trait implementations for CipherText, Left and Right types

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ore-rs"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Dan Draper <dan@cipherstash.com>"]
 edition = "2018"
 homepage = "http://ore.rs"


### PR DESCRIPTION
Bumps the version to include the new changes on main.
