### PR TITLE
Generic Rng

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* ORE Ciphers no longer need to be mutable!
+
 ## [0.2.0]
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ aes = { version = "0.7.5", features = ["armv8"]}
 block-modes = "0.8.1"
 byteorder = "1.4.3"
 hex-literal = "0.3.2"
-rand = "0.3.1"
+rand = "0.8.5"
 rand_chacha = "0.3.1"
 num = "0.4.0"
 

--- a/benches/oreaes128.rs
+++ b/benches/oreaes128.rs
@@ -20,7 +20,7 @@ fn do_compare<const N: usize>(a: &CipherText<OREAES128, N>, b: &CipherText<OREAE
 
 #[inline]
 fn do_compare_slice(a: &[u8], b: &[u8]) {
-    let _ret = OREAES128::<ChaCha20Rng>::compare_raw_slices(a, b);
+    let _ret = OREAES128::compare_raw_slices(a, b);
 }
 
 #[inline]

--- a/benches/oreaes128.rs
+++ b/benches/oreaes128.rs
@@ -1,6 +1,7 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use hex_literal::hex;
 use ore_rs::{scheme::bit2::OREAES128, CipherText, ORECipher, OREEncrypt};
+use rand_chacha::ChaCha20Rng;
 
 #[inline]
 fn do_encrypt_64(input: u64, ore: &mut OREAES128) {
@@ -19,7 +20,7 @@ fn do_compare<const N: usize>(a: &CipherText<OREAES128, N>, b: &CipherText<OREAE
 
 #[inline]
 fn do_compare_slice(a: &[u8], b: &[u8]) {
-    let _ret = OREAES128::compare_raw_slices(a, b);
+    let _ret = OREAES128::<ChaCha20Rng>::compare_raw_slices(a, b);
 }
 
 #[inline]

--- a/src/ciphertext.rs
+++ b/src/ciphertext.rs
@@ -1,4 +1,4 @@
-use crate::primitives::{AesBlock, NONCE_SIZE};
+use crate::primitives::NONCE_SIZE;
 pub use crate::ORECipher;
 
 #[derive(Debug, Copy, Clone)]
@@ -12,7 +12,7 @@ pub struct Left<S: ORECipher, const N: usize> {
 
 #[derive(Debug, Copy, Clone)]
 pub struct Right<S: ORECipher, const N: usize> {
-    pub nonce: AesBlock,
+    pub nonce: [u8; NONCE_SIZE],
     pub data: [S::RightBlockType; N],
 }
 

--- a/src/encrypt.rs
+++ b/src/encrypt.rs
@@ -7,8 +7,8 @@ pub trait OREEncrypt<T: ORECipher> {
     type LeftOutput;
     type FullOutput;
 
-    fn encrypt_left(&self, cipher: &mut T) -> Result<Self::LeftOutput, OREError>;
-    fn encrypt(&self, input: &mut T) -> Result<Self::FullOutput, OREError>;
+    fn encrypt_left(&self, cipher: &T) -> Result<Self::LeftOutput, OREError>;
+    fn encrypt(&self, input: &T) -> Result<Self::FullOutput, OREError>;
 }
 
 // FIXME: I don't like that the cipher is mutable - its private members are mutable
@@ -20,7 +20,7 @@ impl<T: ORECipher> OREEncrypt<T> for u64 {
     type LeftOutput = Left<T, 8>;
     type FullOutput = CipherText<T, 8>;
 
-    fn encrypt_left(&self, cipher: &mut T) -> Result<Self::LeftOutput, OREError>
+    fn encrypt_left(&self, cipher: &T) -> Result<Self::LeftOutput, OREError>
     where
         T::LeftBlockType: CipherTextBlock,
     {
@@ -28,7 +28,7 @@ impl<T: ORECipher> OREEncrypt<T> for u64 {
         cipher.encrypt_left(&bytes)
     }
 
-    fn encrypt(&self, cipher: &mut T) -> Result<Self::FullOutput, OREError>
+    fn encrypt(&self, cipher: &T) -> Result<Self::FullOutput, OREError>
     where
         T::LeftBlockType: CipherTextBlock,
         T::RightBlockType: CipherTextBlock,
@@ -42,12 +42,12 @@ impl<T: ORECipher> OREEncrypt<T> for u32 {
     type LeftOutput = Left<T, 4>;
     type FullOutput = CipherText<T, 4>;
 
-    fn encrypt_left(&self, cipher: &mut T) -> Result<Self::LeftOutput, OREError> {
+    fn encrypt_left(&self, cipher: &T) -> Result<Self::LeftOutput, OREError> {
         let bytes = self.to_be_bytes();
         cipher.encrypt_left(&bytes)
     }
 
-    fn encrypt(&self, cipher: &mut T) -> Result<Self::FullOutput, OREError> {
+    fn encrypt(&self, cipher: &T) -> Result<Self::FullOutput, OREError> {
         let bytes = self.to_be_bytes();
         cipher.encrypt(&bytes)
     }
@@ -57,12 +57,12 @@ impl<T: ORECipher> OREEncrypt<T> for f64 {
     type LeftOutput = Left<T, 8>;
     type FullOutput = CipherText<T, 8>;
 
-    fn encrypt_left(&self, cipher: &mut T) -> Result<Self::LeftOutput, OREError> {
+    fn encrypt_left(&self, cipher: &T) -> Result<Self::LeftOutput, OREError> {
         let plaintext: u64 = self.map_to();
         plaintext.encrypt_left(cipher)
     }
 
-    fn encrypt(&self, cipher: &mut T) -> Result<Self::FullOutput, OREError> {
+    fn encrypt(&self, cipher: &T) -> Result<Self::FullOutput, OREError> {
         let plaintext: u64 = self.map_to();
         plaintext.encrypt(cipher)
     }
@@ -72,11 +72,11 @@ impl<T: ORECipher, const N: usize> OREEncrypt<T> for PlainText<N> {
     type LeftOutput = Left<T, N>;
     type FullOutput = CipherText<T, N>;
 
-    fn encrypt_left(&self, cipher: &mut T) -> Result<Self::LeftOutput, OREError> {
+    fn encrypt_left(&self, cipher: &T) -> Result<Self::LeftOutput, OREError> {
         cipher.encrypt_left(self)
     }
 
-    fn encrypt(&self, cipher: &mut T) -> Result<Self::FullOutput, OREError> {
+    fn encrypt(&self, cipher: &T) -> Result<Self::FullOutput, OREError> {
         cipher.encrypt(self)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,12 +160,12 @@ pub trait ORECipher: Sized {
     fn init(k1: [u8; 16], k2: [u8; 16], seed: &SEED64) -> Result<Self, OREError>;
 
     fn encrypt_left<const N: usize>(
-        &mut self,
+        &self,
         input: &PlainText<N>,
     ) -> Result<Left<Self, N>, OREError>;
 
     fn encrypt<const N: usize>(
-        &mut self,
+        &self,
         input: &PlainText<N>,
     ) -> Result<CipherText<Self, N>, OREError>;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,10 +37,10 @@
 //! let k1: [u8; 16] = hex!("00010203 04050607 08090a0b 0c0d0e0f");
 //! let k2: [u8; 16] = hex!("00010203 04050607 08090a0b 0c0d0e0f");
 //! let seed = hex!("00010203 04050607");
-//! let mut ore: OREAES128 = ORECipher::init(k1, k2, &seed).unwrap();
+//! let ore: OREAES128 = ORECipher::init(k1, k2, &seed).unwrap();
 //!
 //! // Encryption takes a mutable reference to the cipher and returns a `Result`
-//! let a = 456u64.encrypt(&mut ore).unwrap();
+//! let a = 456u64.encrypt(&ore).unwrap();
 //! ```
 //!
 //! *Note that a cipher must be mutable as it manages internal state*.
@@ -65,9 +65,9 @@
 //! # let k1: [u8; 16] = hex!("00010203 04050607 08090a0b 0c0d0e0f");
 //! # let k2: [u8; 16] = hex!("00010203 04050607 08090a0b 0c0d0e0f");
 //! # let seed = hex!("00010203 04050607");
-//! # let mut ore: OREAES128 = ORECipher::init(k1, k2, &seed).unwrap();
-//! let a = 456u64.encrypt(&mut ore).unwrap();
-//! let b = 1024u64.encrypt(&mut ore).unwrap();
+//! # let ore: OREAES128 = ORECipher::init(k1, k2, &seed).unwrap();
+//! let a = 456u64.encrypt(&ore).unwrap();
+//! let b = 1024u64.encrypt(&ore).unwrap();
 //!
 //! // This is fine
 //! let result = a > b; // false because 456 < 1024
@@ -84,10 +84,10 @@
 //! # let k1: [u8; 16] = hex!("00010203 04050607 08090a0b 0c0d0e0f");
 //! # let k2: [u8; 16] = hex!("00010203 04050607 08090a0b 0c0d0e0f");
 //! # let seed = hex!("00010203 04050607");
-//! # let mut ore: OREAES128 = ORECipher::init(k1, k2, &seed).unwrap();
+//! # let ore: OREAES128 = ORECipher::init(k1, k2, &seed).unwrap();
 //! // This isn't
-//! let a = 456u64.encrypt(&mut ore).unwrap();
-//! let b = 1024u32.encrypt(&mut ore).unwrap(); // note the u32
+//! let a = 456u64.encrypt(&ore).unwrap();
+//! let b = 1024u32.encrypt(&ore).unwrap(); // note the u32
 //!
 //! let result = a > b; // compilation error
 //! ```
@@ -110,8 +110,8 @@
 //! # let k1: [u8; 16] = hex!("00010203 04050607 08090a0b 0c0d0e0f");
 //! # let k2: [u8; 16] = hex!("00010203 04050607 08090a0b 0c0d0e0f");
 //! # let seed = hex!("00010203 04050607");
-//! # let mut ore: OREAES128 = ORECipher::init(k1, k2, &seed).unwrap();
-//! let a = 456u64.encrypt(&mut ore).unwrap();
+//! # let ore: OREAES128 = ORECipher::init(k1, k2, &seed).unwrap();
+//! let a = 456u64.encrypt(&ore).unwrap();
 //! let bytes: Vec<u8> = a.to_bytes();
 //! ```
 //!
@@ -129,8 +129,8 @@
 //! # let k1: [u8; 16] = hex!("00010203 04050607 08090a0b 0c0d0e0f");
 //! # let k2: [u8; 16] = hex!("00010203 04050607 08090a0b 0c0d0e0f");
 //! # let seed = hex!("00010203 04050607");
-//! # let mut ore: OREAES128 = ORECipher::init(k1, k2, &seed).unwrap();
-//! # let a = 456u64.encrypt(&mut ore).unwrap();
+//! # let ore: OREAES128 = ORECipher::init(k1, k2, &seed).unwrap();
+//! # let a = 456u64.encrypt(&ore).unwrap();
 //! # let bytes: Vec<u8> = a.to_bytes();
 //!
 //! let ct = CipherText::<OREAES128, 8>::from_bytes(&bytes).unwrap();

--- a/src/scheme/bit2.rs
+++ b/src/scheme/bit2.rs
@@ -59,7 +59,7 @@ impl<R: Rng + SeedableRng> ORECipher for OREAES128<R> {
         });
     }
 
-    fn encrypt_left<const N: usize>(&mut self, x: &PlainText<N>) -> EncryptLeftResult<R, N> {
+    fn encrypt_left<const N: usize>(&self, x: &PlainText<N>) -> EncryptLeftResult<R, N> {
         let mut output = Left::<Self, N>::init();
 
         // Build the prefixes
@@ -99,7 +99,7 @@ impl<R: Rng + SeedableRng> ORECipher for OREAES128<R> {
         Ok(output)
     }
 
-    fn encrypt<const N: usize>(&mut self, x: &PlainText<N>) -> EncryptResult<R, N> {
+    fn encrypt<const N: usize>(&self, x: &PlainText<N>) -> EncryptResult<R, N> {
         let mut left = Left::<Self, N>::init();
         let mut right = Right::<Self, N>::init();
 
@@ -314,9 +314,9 @@ mod tests {
 
     quickcheck! {
         fn compare_u64(x: u64, y: u64) -> bool {
-            let mut ore = init_ore();
-            let a = x.encrypt(&mut ore).unwrap();
-            let b = y.encrypt(&mut ore).unwrap();
+            let ore = init_ore();
+            let a = x.encrypt(&ore).unwrap();
+            let b = y.encrypt(&ore).unwrap();
 
             match x.cmp(&y) {
                 Ordering::Greater => a > b,
@@ -326,9 +326,9 @@ mod tests {
         }
 
         fn compare_u64_raw_slices(x: u64, y: u64) -> bool {
-            let mut ore = init_ore();
-            let a = x.encrypt(&mut ore).unwrap().to_bytes();
-            let b = y.encrypt(&mut ore).unwrap().to_bytes();
+            let ore = init_ore();
+            let a = x.encrypt(&ore).unwrap().to_bytes();
+            let b = y.encrypt(&ore).unwrap().to_bytes();
 
             match ORE::compare_raw_slices(&a, &b) {
                 Some(Ordering::Greater) => x > y,
@@ -339,17 +339,17 @@ mod tests {
         }
 
         fn equality_u64(x: u64) -> bool {
-            let mut ore = init_ore();
-            let a = x.encrypt(&mut ore).unwrap();
-            let b = x.encrypt(&mut ore).unwrap();
+            let ore = init_ore();
+            let a = x.encrypt(&ore).unwrap();
+            let b = x.encrypt(&ore).unwrap();
 
             a == b
         }
 
         fn equality_u64_raw_slices(x: u64) -> bool {
-            let mut ore = init_ore();
-            let a = x.encrypt(&mut ore).unwrap().to_bytes();
-            let b = x.encrypt(&mut ore).unwrap().to_bytes();
+            let ore = init_ore();
+            let a = x.encrypt(&ore).unwrap().to_bytes();
+            let b = x.encrypt(&ore).unwrap().to_bytes();
 
             match ORE::compare_raw_slices(&a, &b) {
                 Some(Ordering::Equal) => true,
@@ -358,9 +358,9 @@ mod tests {
         }
 
         fn compare_u32(x: u32, y: u32) -> bool {
-            let mut ore = init_ore();
-            let a = x.encrypt(&mut ore).unwrap();
-            let b = y.encrypt(&mut ore).unwrap();
+            let ore = init_ore();
+            let a = x.encrypt(&ore).unwrap();
+            let b = y.encrypt(&ore).unwrap();
 
             match x.cmp(&y) {
                 Ordering::Greater => a > b,
@@ -370,9 +370,9 @@ mod tests {
         }
 
         fn equality_u32(x: u64) -> bool {
-            let mut ore = init_ore();
-            let a = x.encrypt(&mut ore).unwrap();
-            let b = x.encrypt(&mut ore).unwrap();
+            let ore = init_ore();
+            let a = x.encrypt(&ore).unwrap();
+            let b = x.encrypt(&ore).unwrap();
 
             a == b
         }
@@ -382,9 +382,9 @@ mod tests {
                 return TestResult::discard();
             }
 
-            let mut ore = init_ore();
-            let a = x.encrypt(&mut ore).unwrap();
-            let b = y.encrypt(&mut ore).unwrap();
+            let ore = init_ore();
+            let a = x.encrypt(&ore).unwrap();
+            let b = y.encrypt(&ore).unwrap();
 
             match x.partial_cmp(&y) {
                 Some(Ordering::Greater) => TestResult::from_bool(a > b),
@@ -399,17 +399,17 @@ mod tests {
          * because NaN == NaN works with the integer encoding
          * */
         fn equality_f64(x: f64) -> bool {
-            let mut ore = init_ore();
-            let a = x.encrypt(&mut ore).unwrap();
-            let b = x.encrypt(&mut ore).unwrap();
+            let ore = init_ore();
+            let a = x.encrypt(&ore).unwrap();
+            let b = x.encrypt(&ore).unwrap();
 
             a == b
         }
 
         fn compare_plaintext(x: u64, y: u64) -> bool {
-            let mut ore = init_ore();
-            let a = x.to_be_bytes().encrypt(&mut ore).unwrap();
-            let b = y.to_be_bytes().encrypt(&mut ore).unwrap();
+            let ore = init_ore();
+            let a = x.to_be_bytes().encrypt(&ore).unwrap();
+            let b = y.to_be_bytes().encrypt(&ore).unwrap();
 
             match x.cmp(&y) {
                 Ordering::Greater => a > b,
@@ -419,9 +419,9 @@ mod tests {
         }
 
         fn equality_plaintext(x: f64) -> bool {
-            let mut ore = init_ore();
-            let a = x.to_be_bytes().encrypt(&mut ore).unwrap();
-            let b = x.to_be_bytes().encrypt(&mut ore).unwrap();
+            let ore = init_ore();
+            let a = x.to_be_bytes().encrypt(&ore).unwrap();
+            let b = x.to_be_bytes().encrypt(&ore).unwrap();
 
             a == b
         }
@@ -429,45 +429,45 @@ mod tests {
 
     #[test]
     fn smallest_to_largest() {
-        let mut ore = init_ore();
-        let a = 0u64.encrypt(&mut ore).unwrap();
-        let b = 18446744073709551615u64.encrypt(&mut ore).unwrap();
+        let ore = init_ore();
+        let a = 0u64.encrypt(&ore).unwrap();
+        let b = 18446744073709551615u64.encrypt(&ore).unwrap();
 
         assert!(a < b);
     }
 
     #[test]
     fn largest_to_smallest() {
-        let mut ore = init_ore();
-        let a = 18446744073709551615u64.encrypt(&mut ore).unwrap();
-        let b = 0u64.encrypt(&mut ore).unwrap();
+        let ore = init_ore();
+        let a = 18446744073709551615u64.encrypt(&ore).unwrap();
+        let b = 0u64.encrypt(&ore).unwrap();
 
         assert!(a > b);
     }
 
     #[test]
     fn smallest_to_smallest() {
-        let mut ore = init_ore();
-        let a = 0u64.encrypt(&mut ore).unwrap();
-        let b = 0u64.encrypt(&mut ore).unwrap();
+        let ore = init_ore();
+        let a = 0u64.encrypt(&ore).unwrap();
+        let b = 0u64.encrypt(&ore).unwrap();
 
         assert!(a == b);
     }
 
     #[test]
     fn largest_to_largest() {
-        let mut ore = init_ore();
-        let a = 18446744073709551615u64.encrypt(&mut ore).unwrap();
-        let b = 18446744073709551615u64.encrypt(&mut ore).unwrap();
+        let ore = init_ore();
+        let a = 18446744073709551615u64.encrypt(&ore).unwrap();
+        let b = 18446744073709551615u64.encrypt(&ore).unwrap();
 
         assert!(a == b);
     }
 
     #[test]
     fn comparisons_in_first_block() {
-        let mut ore = init_ore();
-        let a = 18446744073709551615u64.encrypt(&mut ore).unwrap();
-        let b = 18446744073709551612u64.encrypt(&mut ore).unwrap();
+        let ore = init_ore();
+        let a = 18446744073709551615u64.encrypt(&ore).unwrap();
+        let b = 18446744073709551612u64.encrypt(&ore).unwrap();
 
         assert!(a > b);
         assert!(b < a);
@@ -475,9 +475,9 @@ mod tests {
 
     #[test]
     fn comparisons_in_last_block() {
-        let mut ore = init_ore();
-        let a = 10u64.encrypt(&mut ore).unwrap();
-        let b = 73u64.encrypt(&mut ore).unwrap();
+        let ore = init_ore();
+        let a = 10u64.encrypt(&ore).unwrap();
+        let b = 73u64.encrypt(&ore).unwrap();
 
         assert!(a < b);
         assert!(b > a);
@@ -485,17 +485,17 @@ mod tests {
 
     #[test]
     fn compare_raw_slices_mismatched_lengths() {
-        let mut ore = init_ore();
-        let a_64 = 10u64.encrypt(&mut ore).unwrap().to_bytes();
-        let a_32 = 10u32.encrypt(&mut ore).unwrap().to_bytes();
+        let ore = init_ore();
+        let a_64 = 10u64.encrypt(&ore).unwrap().to_bytes();
+        let a_32 = 10u32.encrypt(&ore).unwrap().to_bytes();
 
         assert_eq!(ORE::compare_raw_slices(&a_64, &a_32), Option::None);
     }
 
     #[test]
     fn binary_encoding() {
-        let mut ore = init_ore();
-        let a = 10u64.encrypt(&mut ore).unwrap();
+        let ore = init_ore();
+        let a = 10u64.encrypt(&ore).unwrap();
         let bin = a.to_bytes();
         assert_eq!(a, CipherText::<OREAES128, 8>::from_bytes(&bin).unwrap());
     }
@@ -520,11 +520,11 @@ mod tests {
         ];
         let seed: [u8; 8] = [119, 104, 41, 110, 199, 157, 235, 169];
 
-        let mut ore1: OREAES128 = ORECipher::init(k1, k2, &seed).unwrap();
-        let mut ore2: OREAES128 = ORECipher::init(k3, k2, &seed).unwrap();
+        let ore1: OREAES128 = ORECipher::init(k1, k2, &seed).unwrap();
+        let ore2: OREAES128 = ORECipher::init(k3, k2, &seed).unwrap();
 
-        let a = 1000u32.encrypt(&mut ore1).unwrap().to_bytes();
-        let b = 1000u32.encrypt(&mut ore2).unwrap().to_bytes();
+        let a = 1000u32.encrypt(&ore1).unwrap().to_bytes();
+        let b = 1000u32.encrypt(&ore2).unwrap().to_bytes();
 
         assert_ne!(Some(Ordering::Equal), ORE::compare_raw_slices(&a, &b));
     }
@@ -542,11 +542,11 @@ mod tests {
         ];
         let seed: [u8; 8] = [119, 104, 41, 110, 199, 157, 235, 169];
 
-        let mut ore1: OREAES128 = ORECipher::init(k1, k2, &seed).unwrap();
-        let mut ore2: OREAES128 = ORECipher::init(k1, k3, &seed).unwrap();
+        let ore1: OREAES128 = ORECipher::init(k1, k2, &seed).unwrap();
+        let ore2: OREAES128 = ORECipher::init(k1, k3, &seed).unwrap();
 
-        let a = 1000u32.encrypt(&mut ore1).unwrap().to_bytes();
-        let b = 1000u32.encrypt(&mut ore2).unwrap().to_bytes();
+        let a = 1000u32.encrypt(&ore1).unwrap().to_bytes();
+        let b = 1000u32.encrypt(&ore2).unwrap().to_bytes();
 
         assert_ne!(Some(Ordering::Equal), ORE::compare_raw_slices(&a, &b));
     }

--- a/src/scheme/bit2.rs
+++ b/src/scheme/bit2.rs
@@ -22,16 +22,18 @@ pub use self::block_types::*;
 
 /* Define our scheme */
 #[derive(Debug)]
-pub struct OREAES128<R=ChaCha20Rng> {
+pub struct OreAes128<R: Rng + SeedableRng> {
     prf1: AES128PRF,
     prf2: AES128PRF,
     rng: RefCell<R>,
     prp_seed: SEED64,
 }
 
+pub type OREAES128 = OreAes128<ChaCha20Rng>;
+
 /* Define some convenience types */
-type EncryptLeftResult<R, const N: usize> = Result<Left<OREAES128<R>, N>, OREError>;
-type EncryptResult<R, const N: usize> = Result<CipherText<OREAES128<R>, N>, OREError>;
+type EncryptLeftResult<R, const N: usize> = Result<Left<OreAes128<R>, N>, OREError>;
+type EncryptResult<R, const N: usize> = Result<CipherText<OreAes128<R>, N>, OREError>;
 
 fn cmp(a: u8, b: u8) -> u8 {
     if a > b {
@@ -41,7 +43,7 @@ fn cmp(a: u8, b: u8) -> u8 {
     }
 }
 
-impl<R: Rng + SeedableRng> ORECipher for OREAES128<R> {
+impl<R: Rng + SeedableRng> ORECipher for OreAes128<R> {
     type LeftBlockType = LeftBlock16;
     type RightBlockType = RightBlock32;
 
@@ -51,7 +53,7 @@ impl<R: Rng + SeedableRng> ORECipher for OREAES128<R> {
 
         let rng: R = SeedableRng::from_entropy();
 
-        return Ok(OREAES128 {
+        return Ok(OreAes128 {
             prf1: Prf::new(GenericArray::from_slice(&k1)),
             prf2: Prf::new(GenericArray::from_slice(&k2)),
             rng: RefCell::new(rng),
@@ -296,7 +298,7 @@ mod tests {
     use crate::encrypt::OREEncrypt;
     use quickcheck::TestResult;
 
-    type ORE = OREAES128::<ChaCha20Rng>;
+    type ORE = OREAES128;
 
     fn init_ore() -> ORE {
         let mut k1: [u8; 16] = Default::default();


### PR DESCRIPTION
This PR:
* Removes the need for ORE Cipher to be mutable by wrapping the `Rng` in a `RefCell`
* Make the bit2 `ORECipher` implementation generic on `Rng`
* Make the default `Rng` for the `bit2` scheme `ChaCha20Rng` instead of `OsRng`

Now things appear to be working in WASM!