### PR TITLE
Compare in constant time

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ rand = "0.8.5"
 rand_chacha = "0.3.1"
 num = "0.4.0"
 hex = "0.4.3"
+subtle-ng = "2.5.0"
 
 
 [[bench]]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,10 +159,8 @@ pub trait ORECipher: Sized {
 
     fn init(k1: [u8; 16], k2: [u8; 16], seed: &SEED64) -> Result<Self, OREError>;
 
-    fn encrypt_left<const N: usize>(
-        &self,
-        input: &PlainText<N>,
-    ) -> Result<Left<Self, N>, OREError>;
+    fn encrypt_left<const N: usize>(&self, input: &PlainText<N>)
+        -> Result<Left<Self, N>, OREError>;
 
     fn encrypt<const N: usize>(
         &self,


### PR DESCRIPTION
Implement constant-time ORE comparison

The subtle-ng crate does most of the heavy-lifting.

Note: we make use of the ConditionallySelectable trait, which does not
provide an implementation for usize, nor can we implement one here
because we own neither the trait definition, nor usize.

To work around it, I use 64 instead and convert back to usize when
required.
