### PR TITLE
Zeroize data after use

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ criterion = "0.3.5"
 quickcheck = "1.0.3"
 
 [dependencies]
-aes = { version = "0.7.5", features = ["armv8"]}
+aes = { version = "0.8.2", features = ["zeroize"]}
 block-modes = "0.8.1"
 byteorder = "1.4.3"
 hex-literal = "0.3.2"
@@ -22,7 +22,7 @@ rand_chacha = "0.3.1"
 num = "0.4.0"
 hex = "0.4.3"
 subtle-ng = "2.5.0"
-
+zeroize = { version = "1.5.7", features = [ "zeroize_derive", "alloc" ] }
 
 [[bench]]
 name = "oreaes128"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ num = "0.4.0"
 hex = "0.4.3"
 subtle-ng = "2.5.0"
 zeroize = { version = "1.5.7", features = [ "zeroize_derive", "alloc" ] }
+lazy_static = "1.4.0"
 
 [[bench]]
 name = "oreaes128"

--- a/benches/oreaes128.rs
+++ b/benches/oreaes128.rs
@@ -47,7 +47,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     let k2 = hex!("d0d007a5 3f9a6848 83bc1f21 0f6595a3");
     let seed = hex!("d0d007a5 3f9a6848");
 
-    let mut ore: OREAES128 = ORECipher::init(k1, k2, &seed).unwrap();
+    let mut ore: OREAES128 = ORECipher::init(&k1, &k2, &seed).unwrap();
     let x_u64 = 100_u64.encrypt(&mut ore).unwrap();
     let y_u64 = 100983939290192_u64.encrypt(&mut ore).unwrap();
 

--- a/examples/encrypt.rs
+++ b/examples/encrypt.rs
@@ -7,7 +7,7 @@ fn main() {
     let k2 = hex!("d0d007a5 3f9a6848 83bc1f21 0f6595a3");
     let seed = hex!("d0d007a5 3f9a6848");
 
-    let ore: OREAES128 = ORECipher::init(k1, k2, &seed).unwrap();
+    let ore: OREAES128 = ORECipher::init(&k1, &k2, &seed).unwrap();
 
     let i = 10000u64;
     let x_u64 = i.encrypt(&ore).unwrap().to_bytes();

--- a/examples/encrypt.rs
+++ b/examples/encrypt.rs
@@ -1,7 +1,6 @@
 use hex_literal::hex;
 use ore_rs::{scheme::bit2::OREAES128, ORECipher, OREEncrypt};
 
-
 fn main() {
     let k1 = hex!("00010203 04050607 08090a0b 0c0d0e0f");
     let k2 = hex!("d0d007a5 3f9a6848 83bc1f21 0f6595a3");

--- a/src/ciphertext.rs
+++ b/src/ciphertext.rs
@@ -29,6 +29,8 @@ pub trait CipherTextBlock: Default + Copy + std::fmt::Debug {
     fn to_bytes(self) -> Vec<u8>;
 
     fn from_bytes(data: &[u8]) -> Result<Self, ParseError>;
+
+    fn default_in_place(&mut self);
 }
 
 #[derive(Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@
 //! let k1: [u8; 16] = hex!("00010203 04050607 08090a0b 0c0d0e0f");
 //! let k2: [u8; 16] = hex!("00010203 04050607 08090a0b 0c0d0e0f");
 //! let seed = hex!("00010203 04050607");
-//! let ore: OREAES128 = ORECipher::init(k1, k2, &seed).unwrap();
+//! let ore: OREAES128 = ORECipher::init(&k1, &k2, &seed).unwrap();
 //!
 //! // Encryption takes a mutable reference to the cipher and returns a `Result`
 //! let a = 456u64.encrypt(&ore).unwrap();
@@ -65,7 +65,7 @@
 //! # let k1: [u8; 16] = hex!("00010203 04050607 08090a0b 0c0d0e0f");
 //! # let k2: [u8; 16] = hex!("00010203 04050607 08090a0b 0c0d0e0f");
 //! # let seed = hex!("00010203 04050607");
-//! # let ore: OREAES128 = ORECipher::init(k1, k2, &seed).unwrap();
+//! # let ore: OREAES128 = ORECipher::init(&k1, &k2, &seed).unwrap();
 //! let a = 456u64.encrypt(&ore).unwrap();
 //! let b = 1024u64.encrypt(&ore).unwrap();
 //!
@@ -84,7 +84,7 @@
 //! # let k1: [u8; 16] = hex!("00010203 04050607 08090a0b 0c0d0e0f");
 //! # let k2: [u8; 16] = hex!("00010203 04050607 08090a0b 0c0d0e0f");
 //! # let seed = hex!("00010203 04050607");
-//! # let ore: OREAES128 = ORECipher::init(k1, k2, &seed).unwrap();
+//! # let ore: OREAES128 = ORECipher::init(&k1, &k2, &seed).unwrap();
 //! // This isn't
 //! let a = 456u64.encrypt(&ore).unwrap();
 //! let b = 1024u32.encrypt(&ore).unwrap(); // note the u32
@@ -110,7 +110,7 @@
 //! # let k1: [u8; 16] = hex!("00010203 04050607 08090a0b 0c0d0e0f");
 //! # let k2: [u8; 16] = hex!("00010203 04050607 08090a0b 0c0d0e0f");
 //! # let seed = hex!("00010203 04050607");
-//! # let ore: OREAES128 = ORECipher::init(k1, k2, &seed).unwrap();
+//! # let ore: OREAES128 = ORECipher::init(&k1, &k2, &seed).unwrap();
 //! let a = 456u64.encrypt(&ore).unwrap();
 //! let bytes: Vec<u8> = a.to_bytes();
 //! ```
@@ -129,7 +129,7 @@
 //! # let k1: [u8; 16] = hex!("00010203 04050607 08090a0b 0c0d0e0f");
 //! # let k2: [u8; 16] = hex!("00010203 04050607 08090a0b 0c0d0e0f");
 //! # let seed = hex!("00010203 04050607");
-//! # let ore: OREAES128 = ORECipher::init(k1, k2, &seed).unwrap();
+//! # let ore: OREAES128 = ORECipher::init(&k1, &k2, &seed).unwrap();
 //! # let a = 456u64.encrypt(&ore).unwrap();
 //! # let bytes: Vec<u8> = a.to_bytes();
 //!
@@ -157,7 +157,7 @@ pub trait ORECipher: Sized {
     type LeftBlockType: CipherTextBlock;
     type RightBlockType: CipherTextBlock;
 
-    fn init(k1: [u8; 16], k2: [u8; 16], seed: &SEED64) -> Result<Self, OREError>;
+    fn init(k1: &[u8; 16], k2: &[u8; 16], seed: &SEED64) -> Result<Self, OREError>;
 
     fn encrypt_left<const N: usize>(&self, input: &PlainText<N>)
         -> Result<Left<Self, N>, OREError>;

--- a/src/primitives/hash.rs
+++ b/src/primitives/hash.rs
@@ -1,7 +1,9 @@
 use crate::primitives::{AesBlock, Hash, HashKey};
-use aes::cipher::{generic_array::GenericArray, BlockEncrypt, NewBlockCipher};
+use aes::cipher::{generic_array::GenericArray, BlockEncrypt, KeyInit};
 use aes::Aes128;
+use zeroize::ZeroizeOnDrop;
 
+#[derive(ZeroizeOnDrop)]
 pub struct AES128Z2Hash {
     cipher: Aes128,
 }

--- a/src/primitives/prf.rs
+++ b/src/primitives/prf.rs
@@ -1,9 +1,11 @@
 use crate::primitives::{AesBlock, PRFKey, Prf};
-use aes::cipher::{BlockEncrypt, NewBlockCipher};
+use aes::cipher::{BlockEncrypt, KeyInit};
 use aes::Aes128;
+use zeroize::ZeroizeOnDrop;
 
-#[derive(Debug)]
+#[derive(Debug, ZeroizeOnDrop)]
 pub struct AES128PRF {
+    // The "zeroize" feature is enabled this will zeroize on it's own
     cipher: Aes128,
 }
 

--- a/src/primitives/prf.rs
+++ b/src/primitives/prf.rs
@@ -5,7 +5,6 @@ use zeroize::ZeroizeOnDrop;
 
 #[derive(Debug, ZeroizeOnDrop)]
 pub struct AES128PRF {
-    // The "zeroize" feature is enabled this will zeroize on it's own
     cipher: Aes128,
 }
 

--- a/src/primitives/prp.rs
+++ b/src/primitives/prp.rs
@@ -7,7 +7,7 @@ use zeroize::{Zeroize, ZeroizeOnDrop};
 #[derive(Zeroize)]
 pub struct KnuthShufflePRP<T: Zeroize, const N: usize> {
     permutation: [T; N],
-    inverse: [T; N]
+    inverse: [T; N],
 }
 
 // For some reason ZeroizeOnDrop doesn't work - so manually do it
@@ -30,7 +30,7 @@ impl Prp<u8> for KnuthShufflePRP<u8, 256> {
 
         let mut perm = Self {
             permutation: [0u8; 256],
-            inverse: [0u8; 256]
+            inverse: [0u8; 256],
         };
 
         // Initialize values
@@ -64,8 +64,8 @@ impl Prp<u8> for KnuthShufflePRP<u8, 256> {
         }
     }
 
-    /* 
-     * Performs the inverse permutation in constant time.     * 
+    /*
+     * Performs the inverse permutation in constant time.
      */
     fn invert(&self, input: u8) -> PRPResult<u8> {
         let index = usize::try_from(input).map_err(|_| PRPError)?;
@@ -94,7 +94,11 @@ mod tests {
         let prp = init_prp()?;
 
         for i in 0..=255 {
-            assert_eq!(i, prp.invert(prp.permute(i)?)?, "permutation round-trip failed");
+            assert_eq!(
+                i,
+                prp.invert(prp.permute(i)?)?,
+                "permutation round-trip failed"
+            );
         }
 
         Ok(())

--- a/src/primitives/prp.rs
+++ b/src/primitives/prp.rs
@@ -2,11 +2,22 @@ pub mod prng;
 use crate::primitives::prp::prng::AES128PRNG;
 use crate::primitives::{PRPError, PRPResult, Prp, SEED64};
 use std::convert::TryFrom;
+use zeroize::{Zeroize, ZeroizeOnDrop};
 
-pub struct KnuthShufflePRP<T, const N: usize> {
+#[derive(Zeroize)]
+pub struct KnuthShufflePRP<T: Zeroize, const N: usize> {
     permutation: [T; N],
     inverse: [T; N]
 }
+
+// For some reason ZeroizeOnDrop doesn't work - so manually
+impl<T: Zeroize, const N: usize> Drop for KnuthShufflePRP<T, N> {
+    fn drop(&mut self) {
+        self.zeroize();
+    }
+}
+
+impl<T: Zeroize, const N: usize> ZeroizeOnDrop for KnuthShufflePRP<T, N> {}
 
 impl Prp<u8> for KnuthShufflePRP<u8, 256> {
     /*

--- a/src/primitives/prp.rs
+++ b/src/primitives/prp.rs
@@ -10,13 +10,14 @@ pub struct KnuthShufflePRP<T: Zeroize, const N: usize> {
     inverse: [T; N]
 }
 
-// For some reason ZeroizeOnDrop doesn't work - so manually
+// For some reason ZeroizeOnDrop doesn't work - so manually do it
 impl<T: Zeroize, const N: usize> Drop for KnuthShufflePRP<T, N> {
     fn drop(&mut self) {
         self.zeroize();
     }
 }
 
+// Impl the ZeroizeOnDrop marker trait since we're zeroizing above
 impl<T: Zeroize, const N: usize> ZeroizeOnDrop for KnuthShufflePRP<T, N> {}
 
 impl Prp<u8> for KnuthShufflePRP<u8, 256> {

--- a/src/primitives/prp/prng.rs
+++ b/src/primitives/prp/prng.rs
@@ -1,6 +1,7 @@
 use crate::primitives::SEED64;
-use aes::cipher::{consts::U16, generic_array::GenericArray, BlockEncrypt, NewBlockCipher};
+use aes::cipher::{consts::U16, generic_array::GenericArray, BlockEncrypt, KeyInit};
 use aes::Aes128;
+use zeroize::Zeroize;
 
 pub struct AES128PRNG {
     cipher: Aes128,
@@ -8,6 +9,16 @@ pub struct AES128PRNG {
     ptr: (usize, usize), // ptr to block and byte within block
     ctr: u32, // increments with each new encryption
     seed: SEED64,
+}
+
+impl Zeroize for AES128PRNG {
+    fn zeroize(&mut self) {
+        for d in self.data.iter_mut() {
+            d.as_mut_slice().zeroize();
+        }
+
+        self.seed.zeroize();
+    }
 }
 
 /*

--- a/src/primitives/prp/prng.rs
+++ b/src/primitives/prp/prng.rs
@@ -7,7 +7,7 @@ pub struct AES128PRNG {
     cipher: Aes128,
     data: [GenericArray<u8, U16>; 16],
     ptr: (usize, usize), // ptr to block and byte within block
-    ctr: u32, // increments with each new encryption
+    ctr: u32,            // increments with each new encryption
     seed: SEED64,
 }
 
@@ -86,7 +86,6 @@ impl AES128PRNG {
         }
     }
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/src/scheme/bit2.rs
+++ b/src/scheme/bit2.rs
@@ -129,7 +129,7 @@ impl<R: Rng + SeedableRng> ORECipher for OreAes128<R> {
             static ref ZEROED_RO_KEYS: [AesBlock; 256] = [Default::default(); 256];
         }
 
-        let mut ro_keys = ZEROED_RO_KEYS.clone();
+        let mut ro_keys = *ZEROED_RO_KEYS;
 
         for n in 0..N {
             // Set prefix and create PRP for the block

--- a/src/scheme/bit2.rs
+++ b/src/scheme/bit2.rs
@@ -17,17 +17,19 @@ use rand_chacha::ChaCha20Rng;
 use std::cell::RefCell;
 use std::cmp::Ordering;
 use subtle_ng::{Choice, ConstantTimeEq, ConditionallySelectable};
+use zeroize::{Zeroize, ZeroizeOnDrop};
 
 pub mod block_types;
 pub use self::block_types::*;
 
 /* Define our scheme */
-#[derive(Debug)]
+#[derive(Debug, ZeroizeOnDrop)]
 pub struct OreAes128<R: Rng + SeedableRng> {
     prf1: AES128PRF,
     prf2: AES128PRF,
+    #[zeroize(skip)]
     rng: RefCell<R>,
-    prp_seed: SEED64,
+    prp_seed: Box<SEED64>,
 }
 
 pub type OREAES128 = OreAes128<ChaCha20Rng>;
@@ -48,17 +50,17 @@ impl<R: Rng + SeedableRng> ORECipher for OreAes128<R> {
     type LeftBlockType = LeftBlock16;
     type RightBlockType = RightBlock32;
 
-    fn init(k1: [u8; 16], k2: [u8; 16], seed: &SEED64) -> Result<Self, OREError> {
+    fn init(k1: &[u8; 16], k2: &[u8; 16], seed: &SEED64) -> Result<Self, OREError> {
         // TODO: k1 and k2 should be Key types and we should have a set of traits to abstract the
         // behaviour ro parsing/loading etc
 
         let rng: R = SeedableRng::from_entropy();
 
         return Ok(OreAes128 {
-            prf1: Prf::new(GenericArray::from_slice(&k1)),
-            prf2: Prf::new(GenericArray::from_slice(&k2)),
+            prf1: Prf::new(GenericArray::from_slice(k1)),
+            prf2: Prf::new(GenericArray::from_slice(k2)),
             rng: RefCell::new(rng),
-            prp_seed: *seed,
+            prp_seed: Box::new(*seed),
         });
     }
 
@@ -86,7 +88,7 @@ impl<R: Rng + SeedableRng> ORECipher for OreAes128<R> {
         }
 
         // Reset the f block
-        // TODO: Should we use Zeroize? We don't actually need to clear sensitive data here, we
+        // We don't actually need to clear sensitive data here, we
         // just need fast "zero set". Reassigning the value will drop the old one and allocate new
         // data to the stack
         output.f = [Default::default(); N];
@@ -128,15 +130,14 @@ impl<R: Rng + SeedableRng> ORECipher for OreAes128<R> {
             left.xt[n] = prp.permute(x[n]).map_err(|_| OREError)?;
 
             // Reset the f block
-            // TODO: Do we need to zeroize the old data before it is dropped due to de-assignment?
-            left.f[n] = Default::default();
+            left.f[n].default_in_place();
 
             left.f[n][0..n].clone_from_slice(&x[0..n]);
             left.f[n][n] = left.xt[n];
             // Include the block number in the value passed to the Random Oracle
             left.f[n][N] = n as u8;
 
-            let mut ro_keys: [AesBlock; 256] = [Default::default(); 256];
+            let mut ro_keys = [AesBlock::default(); 256];
 
             for (j, ro_key) in ro_keys.iter_mut().enumerate() {
                 /*
@@ -169,11 +170,12 @@ impl<R: Rng + SeedableRng> ORECipher for OreAes128<R> {
                 let indicator = cmp(jstar, x[n]);
                 right.data[n].set_bit(j, indicator ^ h);
             }
-        }
-        self.prf1.encrypt_all(&mut left.f);
 
-        // TODO: Do we need to do any zeroing? See https://lib.rs/crates/zeroize
-        // Zeroize the RO Keys before re-assigning them
+            // Zeroize RO keys before the next loop iteration
+            ro_keys.iter_mut().for_each(|x| x.as_mut_slice().zeroize());
+        }
+
+        self.prf1.encrypt_all(&mut left.f);
 
         Ok(CipherText { left, right })
     }
@@ -319,7 +321,7 @@ mod tests {
         rng.fill(&mut k1);
         rng.fill(&mut k2);
 
-        ORECipher::init(k1, k2, &seed).unwrap()
+        ORECipher::init(&k1, &k2, &seed).unwrap()
     }
 
     quickcheck! {
@@ -530,8 +532,8 @@ mod tests {
         ];
         let seed: [u8; 8] = [119, 104, 41, 110, 199, 157, 235, 169];
 
-        let ore1: OREAES128 = ORECipher::init(k1, k2, &seed).unwrap();
-        let ore2: OREAES128 = ORECipher::init(k3, k2, &seed).unwrap();
+        let ore1: OREAES128 = ORECipher::init(&k1, &k2, &seed).unwrap();
+        let ore2: OREAES128 = ORECipher::init(&k3, &k2, &seed).unwrap();
 
         let a = 1000u32.encrypt(&ore1).unwrap().to_bytes();
         let b = 1000u32.encrypt(&ore2).unwrap().to_bytes();
@@ -552,8 +554,8 @@ mod tests {
         ];
         let seed: [u8; 8] = [119, 104, 41, 110, 199, 157, 235, 169];
 
-        let ore1: OREAES128 = ORECipher::init(k1, k2, &seed).unwrap();
-        let ore2: OREAES128 = ORECipher::init(k1, k3, &seed).unwrap();
+        let ore1: OREAES128 = ORECipher::init(&k1, &k2, &seed).unwrap();
+        let ore2: OREAES128 = ORECipher::init(&k1, &k3, &seed).unwrap();
 
         let a = 1000u32.encrypt(&ore1).unwrap().to_bytes();
         let b = 1000u32.encrypt(&ore2).unwrap().to_bytes();

--- a/src/scheme/bit2/block_types.rs
+++ b/src/scheme/bit2/block_types.rs
@@ -1,3 +1,5 @@
+use zeroize::Zeroize;
+
 use crate::ciphertext::{CipherTextBlock, ParseError};
 use crate::primitives::AesBlock;
 
@@ -48,6 +50,10 @@ impl CipherTextBlock for LeftBlock16 {
             Ok(Self::clone_from_slice(data))
         }
     }
+
+    fn default_in_place(&mut self) {
+        self.zeroize()
+    }
 }
 
 impl CipherTextBlock for RightBlock32 {
@@ -67,6 +73,10 @@ impl CipherTextBlock for RightBlock32 {
 
             Ok(Self { data: arr })
         }
+    }
+
+    fn default_in_place(&mut self) {
+        self.data.zeroize()
     }
 }
 

--- a/src/scheme/bit2/block_types.rs
+++ b/src/scheme/bit2/block_types.rs
@@ -96,4 +96,19 @@ mod tests {
         block.set_bit(255, 1);
         assert_eq!(block.get_bit(255), 1);
     }
+
+    #[test]
+    fn right_default_in_place_without_new_data() {
+        let mut right = RightBlock32::default();
+        right.data.copy_from_slice(&[1; 32]);
+
+        let ptr: *const [u8] = &right.data;
+
+        assert_eq!(unsafe { &*ptr }, &[1; 32]);
+
+        right.default_in_place();
+
+        assert_eq!(unsafe { &*ptr }, &[0; 32]);
+        assert_eq!(right.data, [0; 32]);
+    }
 }


### PR DESCRIPTION
Uses the Zeroize crate plus some manual zeroizing to ensure that any potentially sensitive data is cleaned up after use.

- Zeroize, update aes
- Add zero test for block
- Update to take keys by reference to avoid Rust moving / copying data
- Zero keys used inside encrypt method
