### PR TITLE
Improved uniformity of PRP generation

### DIFF
--- a/benches/oreaes128.rs
+++ b/benches/oreaes128.rs
@@ -1,7 +1,6 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use hex_literal::hex;
 use ore_rs::{scheme::bit2::OREAES128, CipherText, ORECipher, OREEncrypt};
-use rand_chacha::ChaCha20Rng;
 
 #[inline]
 fn do_encrypt_64(input: u64, ore: &mut OREAES128) {

--- a/src/primitives/prp.rs
+++ b/src/primitives/prp.rs
@@ -81,7 +81,7 @@ mod tests {
     fn test_invert() -> Result<(), PRPError> {
         let prp = init_prp()?;
 
-        for i in 0..255 {
+        for i in 0..=255 {
             assert_eq!(i, prp.invert(prp.permute(i)?)?, "permutation round-trip failed");
         }
 

--- a/src/primitives/prp.rs
+++ b/src/primitives/prp.rs
@@ -14,7 +14,7 @@ impl Prp<u8> for KnuthShufflePRP<u8, 256> {
      * and a 64-bit random seed
      */
     fn new(key: &[u8], seed: &SEED64) -> PRPResult<Self> {
-        let mut prg = AES128PRNG::init(key, seed); // TODO: Use Result type here, too
+        let mut rng = AES128PRNG::init(key, seed); // TODO: Use Result type here, too
 
         let mut perm = Self {
             permutation: [0u8; 256],
@@ -26,10 +26,10 @@ impl Prp<u8> for KnuthShufflePRP<u8, 256> {
             perm.permutation[i] = i as u8;
         }
 
-        for elem in 0..perm.permutation.len() {
-            let j = prg.next_byte();
-            perm.permutation.swap(elem, usize::try_from(j).map_err(|_| PRPError)?);
-        }
+        (0..(256usize)).into_iter().rev().for_each(|i| {
+            let j = rng.gen_range(i as u8);
+            perm.permutation.swap(i, j as usize);
+        });
 
         for (index, val) in perm.permutation.iter().enumerate() {
             perm.inverse[*val as usize] = index as u8;
@@ -82,7 +82,7 @@ mod tests {
         let prp = init_prp()?;
 
         for i in 0..255 {
-            assert_eq!(i, prp.invert(prp.permute(i)?)?);
+            assert_eq!(i, prp.invert(prp.permute(i)?)?, "permutation round-trip failed");
         }
 
         Ok(())

--- a/src/primitives/prp.rs
+++ b/src/primitives/prp.rs
@@ -26,7 +26,7 @@ impl Prp<u8> for KnuthShufflePRP<u8, 256> {
             perm.permutation[i] = i as u8;
         }
 
-        (0..(256usize)).into_iter().rev().for_each(|i| {
+        (0..=255usize).into_iter().rev().for_each(|i| {
             let j = rng.gen_range(i as u8);
             perm.permutation.swap(i, j as usize);
         });

--- a/src/primitives/prp/prng.rs
+++ b/src/primitives/prp/prng.rs
@@ -56,7 +56,7 @@ impl AES128PRNG {
         for i in 0..16 {
             // Counter
             self.data[i][0..4].copy_from_slice(&self.ctr.to_be_bytes());
-            self.ctr = self.ctr + 1;
+            self.ctr += 1;
             self.data[i][8..16].copy_from_slice(&self.seed);
         }
         self.cipher.encrypt_blocks(&mut self.data);


### PR DESCRIPTION
This PRP corrects some possible modulo bias in the KnuthShuffle. It also extends the AES based PRNG to generate up to 4*16 billion values which is overkill but means successive iteration won't run out of Rng entropy.