### PR TITLE
fix: canonicalise -0.0 to +0.0 in f64 ORE encoding

### DIFF
--- a/src/convert.rs
+++ b/src/convert.rs
@@ -35,7 +35,9 @@ trait FromOrderedInteger<T> {
 
 impl ToOrderedInteger<u64> for f64 {
     fn map_to(&self) -> u64 {
-        let num: u64 = self.to_bits();
+        // Canonicalise -0.0 to +0.0 so equal-comparing floats produce equal
+        // ciphertexts (IEEE-754: -0.0 == +0.0).
+        let num: u64 = if *self == 0.0 { 0 } else { self.to_bits() };
         let signed: i64 = -(unsafe { mem::transmute(num >> 63) });
         let mut mask: u64 = unsafe { mem::transmute(signed) };
         mask |= 0x8000000000000000;

--- a/src/scheme/bit2.rs
+++ b/src/scheme/bit2.rs
@@ -466,6 +466,21 @@ mod tests {
         assert!(a == b);
     }
 
+    // Regression: IEEE-754 says -0.0 == +0.0, so their ciphertexts must
+    // compare equal. Previously, sign-bit handling in
+    // `ToOrderedInteger::map_to` produced different `u64` plaintexts for
+    // the two zeros (0x7FFF... vs 0x8000...), so a quickcheck draw of
+    // `(-0.0, 0.0)` would flake. Pin the contract deterministically.
+    #[test]
+    fn signed_zeros_compare_equal() {
+        let ore = init_ore();
+        let pos_zero = 0.0_f64.encrypt(&ore).unwrap();
+        let neg_zero = (-0.0_f64).encrypt(&ore).unwrap();
+
+        assert_eq!(0.0_f64.partial_cmp(&-0.0_f64), Some(Ordering::Equal));
+        assert!(pos_zero == neg_zero);
+    }
+
     #[test]
     fn comparisons_in_first_block() {
         let ore = init_ore();


### PR DESCRIPTION
## Summary

- Mask zero before bit-conversion in \`ToOrderedInteger<u64> for f64\` so \`-0.0\` and \`+0.0\` produce the same plaintext \`u64\`, matching IEEE-754 \`-0.0 == +0.0\`.
- Add a deterministic regression test (\`signed_zeros_compare_equal\`) so this contract no longer relies on a quickcheck draw of the \`(-0.0, 0.0)\` pair.

## Why

\`compare_f64\` in \`scheme::bit2::tests\` is intermittently flaky: when quickcheck happened to draw \`(-0.0, 0.0)\`, \`partial_cmp\` returned \`Equal\` but the encoded \`u64\`s differed (\`0x7FFF_FFFF_FFFF_FFFF\` vs \`0x8000_0000_0000_0000\`), so the resulting ciphertexts compared unequal.

## Compatibility

Stored ciphertexts for every \`f64\` value other than \`-0.0\` are bit-identical before and after this change. Only encryptions of \`-0.0\` are affected — and those were already producing incorrect equality results against \`+0.0\`. NaN / ±Inf are documented as undefined and unchanged.

## Test plan

- [x] \`signed_zeros_compare_equal\` fails before the fix, passes after
- [x] \`cargo test\` full suite green
- [x] \`compare_f64\` quickcheck no longer flakes (re-ran 5×)