### PR TITLE
fix(prp): zeroize Aes128Prng keystream on drop (ZA-0001)

### DIFF
--- a/packages/ore-rs/src/primitives/prp/prng.rs
+++ b/packages/ore-rs/src/primitives/prp/prng.rs
@@ -170,11 +170,12 @@ mod tests {
     // Compile-time check that the `ZeroizeOnDrop` *marker* is present (so
     // downstream `T: ZeroizeOnDrop` bounds hold). This does NOT prove the wipe
     // actually runs — `drop_zeroizes_keystream` below covers the runtime path.
-    #[test]
-    fn impls_zeroize_on_drop() {
+    // Written as a compile-time assertion (cf. lines 43-46) rather than a
+    // runtime `#[test]`, since nothing here executes at run time.
+    const _: fn() = || {
         fn assert_zod<T: ZeroizeOnDrop>() {}
         assert_zod::<Aes128Prng>();
-    }
+    };
 
     // Exercises the real `Drop -> zeroize()` path (the only path the PRP uses;
     // it never calls `zeroize()` explicitly). Runs the synthesised destructor

--- a/packages/ore-rs/src/primitives/prp/prng.rs
+++ b/packages/ore-rs/src/primitives/prp/prng.rs
@@ -1,6 +1,6 @@
 use aes::cipher::{consts::U16, generic_array::GenericArray, BlockEncrypt, KeyInit};
 use aes::Aes128;
-use zeroize::Zeroize;
+use zeroize::{Zeroize, ZeroizeOnDrop};
 
 pub struct Aes128Prng {
     cipher: Aes128,
@@ -14,8 +14,26 @@ impl Zeroize for Aes128Prng {
         for d in self.data.iter_mut() {
             d.as_mut_slice().zeroize();
         }
+        // Also clear the keystream position/counter state (ZA-0001).
+        self.ptr.0.zeroize();
+        self.ptr.1.zeroize();
+        self.ctr.zeroize();
     }
 }
+
+// `Aes128Prng` is built per-block inside the PRP and dropped without an
+// explicit `zeroize()` call, so its key-derived keystream (`data`) must be
+// wiped on drop (ZA-0001). The `cipher` field's AES key schedule is already
+// wiped by the `aes` crate's own `ZeroizeOnDrop` (the `zeroize` feature) when
+// it drops after this. As with `KnuthShufflePRP`, the `ZeroizeOnDrop` derive
+// does not apply cleanly here, so impl `Drop` manually and assert the marker.
+impl Drop for Aes128Prng {
+    fn drop(&mut self) {
+        self.zeroize();
+    }
+}
+
+impl ZeroizeOnDrop for Aes128Prng {}
 
 /*
  * To aid in performance this PRNG can only generate 256 random numbers
@@ -112,5 +130,38 @@ mod tests {
         for _i in 0..=100_000 {
             prg.next_byte();
         }
+    }
+
+    // ZA-0001 regression: `zeroize()` must wipe the key-derived keystream
+    // *and* the position/counter state, and the type must be `ZeroizeOnDrop`
+    // so the wipe is triggered on drop (it is never called explicitly by the
+    // PRP). The `cipher` AES key schedule is wiped separately by the `aes`
+    // crate's own `ZeroizeOnDrop` when it drops.
+    #[test]
+    fn zeroize_clears_keystream_and_state() {
+        let mut prng = init_prng();
+        for _ in 0..20 {
+            let _ = prng.next_byte();
+        }
+        // Precondition: there is real state to wipe.
+        assert_ne!(prng.ctr, 0);
+        assert!(prng.data.iter().any(|b| b.iter().any(|&x| x != 0)));
+
+        prng.zeroize();
+
+        assert!(
+            prng.data.iter().all(|b| b.iter().all(|&x| x == 0)),
+            "keystream not cleared"
+        );
+        assert_eq!(prng.ptr, (0, 0), "position not cleared");
+        assert_eq!(prng.ctr, 0, "counter not cleared");
+    }
+
+    // Compile-time proof that the wipe runs on drop (not only on an explicit
+    // `zeroize()` the PRP never makes).
+    #[test]
+    fn impls_zeroize_on_drop() {
+        fn assert_zod<T: ZeroizeOnDrop>() {}
+        assert_zod::<Aes128Prng>();
     }
 }

--- a/packages/ore-rs/src/primitives/prp/prng.rs
+++ b/packages/ore-rs/src/primitives/prp/prng.rs
@@ -35,6 +35,16 @@ impl Drop for Aes128Prng {
 
 impl ZeroizeOnDrop for Aes128Prng {}
 
+// The drop-time wipe of `cipher` (the AES key schedule) relies entirely on
+// `aes::Aes128: ZeroizeOnDrop`, which is gated behind the `aes` crate's
+// `zeroize` feature. Assert it at compile time so the build fails fast if that
+// feature is ever lost — otherwise the key-schedule wipe would silently vanish
+// while this type still (falsely) claims `ZeroizeOnDrop`.
+const _: fn() = || {
+    fn assert_zeroize_on_drop<T: ZeroizeOnDrop>() {}
+    assert_zeroize_on_drop::<Aes128>();
+};
+
 /*
  * To aid in performance this PRNG can only generate 256 random numbers
  * before it panics. Should _only_ be used inside the PRP.
@@ -157,11 +167,47 @@ mod tests {
         assert_eq!(prng.ctr, 0, "counter not cleared");
     }
 
-    // Compile-time proof that the wipe runs on drop (not only on an explicit
-    // `zeroize()` the PRP never makes).
+    // Compile-time check that the `ZeroizeOnDrop` *marker* is present (so
+    // downstream `T: ZeroizeOnDrop` bounds hold). This does NOT prove the wipe
+    // actually runs — `drop_zeroizes_keystream` below covers the runtime path.
     #[test]
     fn impls_zeroize_on_drop() {
         fn assert_zod<T: ZeroizeOnDrop>() {}
         assert_zod::<Aes128Prng>();
+    }
+
+    // Exercises the real `Drop -> zeroize()` path (the only path the PRP uses;
+    // it never calls `zeroize()` explicitly). Runs the synthesised destructor
+    // in place on storage we still own (never freed, via `ManuallyDrop`), then
+    // volatile-reads the keystream — the technique the ZA-0001 audit PoC was
+    // verified against. Catches deletion of `impl Drop` even if the marker is
+    // kept (which `impls_zeroize_on_drop` and the explicit-`zeroize` test miss).
+    #[test]
+    fn drop_zeroizes_keystream() {
+        use core::mem::{size_of, ManuallyDrop};
+        use core::ptr;
+
+        let key: [u8; 16] = hex!("00010203 04050607 08090a0b 0c0d0e0f");
+        let mut prng = ManuallyDrop::new(Aes128Prng::init(&key));
+        let _ = prng.next_byte(); // ensure `data` holds real keystream
+
+        // Raw pointers (via `addr_of!`, no intermediate references) so running
+        // the destructor and reading the bytes stays provenance-clean.
+        let p: *mut Aes128Prng = &mut *prng as *mut Aes128Prng;
+        let data_ptr = unsafe { ptr::addr_of!((*p).data) as *const u8 };
+        let data_len = size_of::<[GenericArray<u8, U16>; 16]>();
+
+        let survived = unsafe {
+            ptr::drop_in_place(p); // runs Drop -> zeroize(); storage stays owned
+            (0..data_len)
+                .filter(|&i| ptr::read_volatile(data_ptr.add(i)) != 0)
+                .count()
+        };
+        // `prng` is `ManuallyDrop`, so it is not dropped again here.
+
+        assert_eq!(
+            survived, 0,
+            "Drop did not zeroize keystream: {survived}/{data_len} bytes survived"
+        );
     }
 }


### PR DESCRIPTION
Closes #85

## Summary

`Aes128Prng` (the AES-CTR keystream PRNG behind the legacy Knuth-shuffle PRP)
implemented `Zeroize` but had **no `Drop`/`ZeroizeOnDrop`**, so its manual
`zeroize()` was never triggered — the PRP builds one per block and drops it
without an explicit wipe. The compiler-synthesised drop glue only delegated to
the `cipher` field, leaving the **key-derived AES-CTR keystream (`data`)** plus
the position/counter state in the reclaimed stack frame.

## Fix

- Add a manual `impl Drop` that calls `zeroize()`, and assert the
  `ZeroizeOnDrop` marker — matching the existing `KnuthShufflePRP` convention,
  since the derive does not apply cleanly to these types.
- Extend `zeroize()` to also clear `ptr`/`ctr`, not just `data`.
- `cipher`'s AES key schedule is intentionally left to the `aes` crate's own
  `ZeroizeOnDrop` (the `zeroize` feature), which wipes it when it drops after
  this — confirmed by LLVM-IR analysis (the wipe survives `-O2` on both the
  normal and unwind paths).

## Provenance

Found by the Trail of Bits **`zeroize-audit`** skill (finding **ZA-0001**,
medium/confirmed) and PoC-verified: **253/256** keystream bytes survived drop
before this change, **0/256** after. The audit also confirmed nothing is
optimized away and the AES key schedule itself was already wiped.

## Verification

- New regression tests: `zeroize` clears all state, and the type is
  `ZeroizeOnDrop`.
- `cargo fmt --check`, `clippy -D warnings`, full lib suite — all green.
- **No wire-format change** (compat vectors unchanged).

## Note for the ORE v2 stack

This targets `main` (shipped 0.8.x code). The v2 stack's branch `feat/ore-v2-chained`
independently refactored `prng.rs` (`ptr: (usize,usize)` → flat `usize`) but did
**not** fix ZA-0001 — the finding is still live there. On rebasing the stack onto
a `main` containing this fix, expect a small mechanical conflict in `prng.rs`:
resolve `self.ptr.0.zeroize(); self.ptr.1.zeroize();` → `self.ptr.zeroize();`.
The `Drop` impl, marker, `ctr` wipe, and tests carry over cleanly.