### PR TITLE
docs: refresh crates.io/docs.rs-facing docs and crate metadata

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,9 +2,9 @@
 
 ## Supported Versions
 
-| Version | Supported          |
-| ------- | ------------------ |
-| 0.1.x   | :white_check_mark: |
+This repository publishes the `ore-rs` and `orderable-bytes` crates.
+
+**Security fixes are released for the latest release line of each crate.** Security reports are welcome for any version, but fixes land in the latest release — if you are on an older version, plan to upgrade to receive them.
 
 ## Reporting a Vulnerability
 

--- a/packages/orderable-bytes/Cargo.toml
+++ b/packages/orderable-bytes/Cargo.toml
@@ -7,6 +7,8 @@ authors = [
 ]
 edition = "2021"
 homepage = "https://cipherstash.com"
+repository = "https://github.com/cipherstash/ore.rs"
+documentation = "https://docs.rs/orderable-bytes"
 description = "Canonical, order-preserving fixed-length byte encodings for plaintext types — feed into ORE or OPE schemes that compare encrypted values lexicographically"
 license-file = "../../LICENCE"
 readme = "README.md"

--- a/packages/orderable-bytes/README.md
+++ b/packages/orderable-bytes/README.md
@@ -4,7 +4,7 @@ Pre-encryption byte encodings for **order-revealing encryption** (ORE) and **ord
 
 ORE and OPE both produce ciphertexts whose byte-wise comparison reveals the order of the underlying plaintexts. To exploit that property you first need to convert your plaintext — a `Decimal`, a `NaiveDate`, a `DateTime<Utc>`, … — into a canonical byte sequence whose lexicographic order already matches the value's natural total order. **That conversion is what this crate does.** Plug the bytes into an ORE or OPE primitive and the resulting ciphertext inherits the same order and equality semantics as the original plaintext.
 
-Each module exposes a `to_orderable_bytes` function and an `ENCODED_LEN` constant. The bytes have two guarantees:
+Primitive types (`bool`, all integer widths, `char`, `f32`/`f64`) implement the `ToOrderableBytes` trait via the always-available `primitive` module; `Decimal` and `chrono` types are covered by feature-gated modules, each exposing a `to_orderable_bytes` function and an `ENCODED_LEN` constant. The bytes have two guarantees:
 
 - **byte-wise lexicographic order agrees with the type's natural total order**
 - **byte equality agrees with value equality**
@@ -17,6 +17,7 @@ Encoders are gated behind per-type feature flags so callers only pay for the dep
 
 | Feature  | Path                                            | Type                       | `ENCODED_LEN` |
 |----------|-------------------------------------------------|----------------------------|---------------|
+| (none)   | `primitive` (`ToOrderableBytes` impls)          | `bool`, `u8`–`u128`, `i8`–`i128`, `char`, `f32`, `f64` | per type |
 | `decimal`| `decimal::to_orderable_bytes`                   | `rust_decimal::Decimal`    | 14            |
 | `chrono` | `chrono::naive_date::to_orderable_bytes`        | `chrono::NaiveDate`        | 4             |
 | `chrono` | `chrono::datetime_utc::to_orderable_bytes`      | `chrono::DateTime<Utc>`    | 12            |

--- a/packages/ore-rs/Cargo.toml
+++ b/packages/ore-rs/Cargo.toml
@@ -7,6 +7,8 @@ authors = [
 ]
 edition = "2018"
 homepage = "https://cipherstash.com"
+repository = "https://github.com/cipherstash/ore.rs"
+documentation = "https://docs.rs/ore-rs"
 description = "Order-revealing encryption library used by the CipherStash searchable encryption platform"
 license-file = "../../LICENCE"
 readme = "README.md"

--- a/packages/ore-rs/README.md
+++ b/packages/ore-rs/README.md
@@ -1,6 +1,6 @@
-# ore.rs
+# ore-rs
 
-_(pronounced "auras")_
+Part of the [ore.rs](https://github.com/cipherstash/ore.rs) workspace _(pronounced "auras")_, alongside [`orderable-bytes`](https://crates.io/crates/orderable-bytes).
 
 [![Test](https://github.com/cipherstash/ore.rs/actions/workflows/test.yml/badge.svg)](https://github.com/cipherstash/ore.rs/actions/workflows/test.yml)
 
@@ -12,16 +12,23 @@ It makes the following improvements on the original scheme:
 * Use of a Knuth (Fisher-Yates) Shuffle for the PRP (instead of a Feistel Network which was found to be insecure for small domains (see [Bogatov et al](https://eprint.iacr.org/2018/953.pdf))
 * Exclusive use of AES as a Random Oracle
 * Pipeline optimisations, for higher throughput
-* Both SIMD and Neon intrinsic support for `x86_64` and `ARM`
+* Hardware AES acceleration on `x86_64` and ARM (via the [`aes`](https://crates.io/crates/aes) crate's runtime detection, on stable Rust)
 * Inclusion of the block number in block prefixes, to avoid repeated prefixes
 
 ## Usage Documentation
 
 Reference documentation is on [docs.rs/ore-rs](https://docs.rs/ore-rs).
 
+## Supported plaintext types
+
+`OreEncrypt` is implemented for `bool`, all integer widths (`u8`–`u128`, `i8`–`i128`), `char`, `f32`, and `f64`. Two optional features extend this via the sibling [`orderable-bytes`](https://crates.io/crates/orderable-bytes) crate:
+
+- `chrono` — ORE support for `chrono::NaiveDate` and `chrono::DateTime<Utc>`
+- `decimal` — ORE support for `rust_decimal::Decimal`
+
 ## Need help?
 
-Head over to our [support forum](https://discuss.cipherstash.com/), and we'll get back to you super quick! 
+Please [open an issue](https://github.com/cipherstash/ore.rs/issues) and we'll get back to you.
 
 ## Build, Test and Bench
 
@@ -43,36 +50,19 @@ To run the benchmarks, run:
 cargo bench
 ```
 
-Example benchmark results below:
+Example benchmark results below (from December 2021):
 
 ![Benchmark](https://user-images.githubusercontent.com/12306/145158987-9846bd94-24c7-4163-b655-1cb3ad686dd9.png)
 
-## ARMv8 and M1 Support
+## ARMv8 and Apple Silicon support
 
-ARMv8 and M1 Macs work out of the box but will default to AES in software which is around 4x slower than AES-NI (at least on the test machine using an Intel i7 8700K).
+Hardware AES is provided by the [`aes`](https://crates.io/crates/aes) crate, which uses runtime CPU-feature detection on both `x86_64` (AES-NI) and ARMv8 (NEON AES intrinsics) — on stable Rust, with no special configuration required.
 
-To take advantage of hardware AES using NEON Intrinsics on ARM, you need to use Rust nightly.
+## Security
 
-```
-asdf install rust nightly
-asdf local rust nightly
-cargo +nightly bench
-```
+The underlying scheme (Lewi-Wu Block-ORE) has been well studied, but this implementation has not had a public third-party audit. Evaluate it against your own threat model before using it in production.
 
-## Security Warning
-
-This package is a pre-1.0 release and has not yet had significant scrutiny (although ORE generally has been quite well studied).
-We are planning to have a 3rd party audit performed prior to the release of 1.0.
-
-In the mean-time: Use at your own risk!
-
-## 1.0 Roadmap
-
-- External Audit
-- Simpler ciphertext internals (which should improve performance)
-- Further constant time improvements
-- Additional block sizes
-- Trinary indicator function support (avoids needing to store left-ciphertexts)
+To report a security issue, see [SECURITY.md](https://github.com/cipherstash/ore.rs/blob/main/SECURITY.md) or email security@cipherstash.com.
 
 ## License
 

--- a/packages/ore-rs/src/lib.rs
+++ b/packages/ore-rs/src/lib.rs
@@ -12,13 +12,14 @@
 //! used by adding `ore-rs` to your dependencies in your project's `Cargo.toml`.
 //! ```toml
 //! [dependencies]
-//! ore-rs = "0.1"
+//! ore-rs = "0.8"
 //! ```
 //!
 //! ## Example: Encrypt a number with ORE.
 //!
-//! To encrypt a number you need to initalize an [`OreCipher`] as well as `use` the [`OreEncrypt`] trait
-//! which comes with implementations for `u32` and `u64`.
+//! To encrypt a number you need to initalize an [`OreCipher`] as well as `use` the [`OreEncrypt`] trait,
+//! which comes with implementations for `bool`, all integer widths (`u8`–`u128`, `i8`–`i128`), `char`,
+//! `f32` and `f64` (plus `chrono` and `rust_decimal` types behind the `chrono`/`decimal` features).
 //!
 //! To initalize the Cipher, you must decide on the scheme you want to use. There is only one ORE
 //! Scheme right now so that's easy but in the future more schemes will become available.
@@ -38,11 +39,9 @@
 //! let k2: [u8; 16] = hex!("00010203 04050607 08090a0b 0c0d0e0f");
 //! let ore: OreAes128ChaCha20 = OreCipher::init(&k1, &k2).unwrap();
 //!
-//! // Encryption takes a mutable reference to the cipher and returns a `Result`
+//! // Encryption takes a reference to the cipher and returns a `Result`
 //! let a = 456u64.encrypt(&ore).unwrap();
 //! ```
-//!
-//! *Note that a cipher must be mutable as it manages internal state*.
 //!
 //!
 //! ## Example: Comparing 2 CipherTexts

--- a/packages/ore-rs/src/lib.rs
+++ b/packages/ore-rs/src/lib.rs
@@ -17,11 +17,11 @@
 //!
 //! ## Example: Encrypt a number with ORE.
 //!
-//! To encrypt a number you need to initalize an [`OreCipher`] as well as `use` the [`OreEncrypt`] trait,
+//! To encrypt a number you need to initialize an [`OreCipher`] as well as `use` the [`OreEncrypt`] trait,
 //! which comes with implementations for `bool`, all integer widths (`u8`–`u128`, `i8`–`i128`), `char`,
 //! `f32` and `f64` (plus `chrono` and `rust_decimal` types behind the `chrono`/`decimal` features).
 //!
-//! To initalize the Cipher, you must decide on the scheme you want to use. There is only one ORE
+//! To initialize the Cipher, you must decide on the scheme you want to use. There is only one ORE
 //! Scheme right now so that's easy but in the future more schemes will become available.
 //!
 //! An `OreCipher` also requires 2 keys (16-bytes each) and an 8-byte seed.


### PR DESCRIPTION
## Summary

Meta-file staleness sweep. The two artifacts external users actually see — the crates.io README and the docs.rs front page — carried 2021-era content:

- **ore-rs README**: dead `discuss.cipherstash.com` support link (DNS no longer resolves); an "ARMv8 needs Rust nightly for hardware AES" section that is no longer true (zero NEON/nightly/arch-specific code in the repo — hardware AES comes from the `aes` crate's runtime detection on stable, and CI pins stable); the five-year-old "1.0 Roadmap"; no mention of the `chrono`/`decimal` features or supported plaintext types. All fixed; benchmark image labeled with its date.
- **lib.rs rustdoc**: install snippet said `ore-rs = "0.1"` (crate is 0.8.3); claimed `OreEncrypt` covers "`u32` and `u64`" (it covers bool, all integer widths, char, floats + feature-gated chrono/decimal); a "*cipher must be mutable*" note contradicted the adjacent example, which borrows immutably. `cargo test --doc -p ore-rs` passes (5/5).
- **SECURITY.md**: said only 0.1.x is supported. Now a latest-release-line policy covering both published crates.
- **Cargo.toml (both crates)**: added `repository`/`documentation` — crates.io currently shows `repository: null` for both, so their pages have no source link.
- **orderable-bytes README**: documents the pre-trait API; now mentions `ToOrderableBytes` and the always-available `primitive` encoders that ship with the next release.

## Flagged, not changed (needs your call)

1. **ZA-0001 is merged but unreleased** — the zeroize hardening (merged June 16) is sitting on main while crates.io is still 0.8.3 (released May 5). Recommend cutting 0.8.4.
2. **Security wording**: I kept "no public third-party audit" as the conservative claim — if an audit has happened since 2021, that line should be updated.
3. **Changelogs are malformed** (ore-rs jumps Unreleased→0.3.0 with 0.4–0.8 missing; orderable-bytes has no version headings at all). This looks like cliff.toml/release-plz output config, so I left it rather than fight the generator.
4. **Workspace `[patch.crates-io]` pins bumpalo to a git rev** with no explanation — transitive dev-dep only, but unexplained git pins in a crypto repo are supply-chain surface worth a comment or removal.

Closes #92
